### PR TITLE
fix: createRequireFromPath is deprecated, use createRequire

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ⚠️ Warning note ⚠ ️  
 
 1) This is very experimental  
-2) Node.js' latest version (12.0.0) is required  
+2) Node.js version 12.2.0+ is required  
 3) You should run Node.js with the `--experimental-modules` flag  
 4) You probably should run Node.js with the `--es-module-specifier-resolution=node` flag  
 
@@ -27,7 +27,7 @@ No solution was found to fix it until now.
 PRs are welcome.  
 
 ## How to use
-1) Be sure you're using Node.js >12.0.0  
+1) Be sure you're using Node.js >12.2.0 
 2) The flags, you should use the flags: `--experimental-modules` and `--es-module-specifier-resolution=node`  
 3) You can use npm scripts to run your app, something like this:  
 ```

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
-import { createRequireFromPath } from 'module';
+import { createRequire } from 'module';
 import { fileURLToPath } from 'url';
-const requireModule = createRequireFromPath(fileURLToPath(import.meta.url));
+const requireModule = createRequire(fileURLToPath(import.meta.url));
 
 export default function require(modulePath) {
     return requireModule(modulePath);


### PR DESCRIPTION
This package no longer works with newer versions of Node due to[ `createRequireFromPath` being deprecated](https://nodejs.org/api/deprecations.html#DEP0130) from Node 13 onwards and reaching end-of-life at Node 16; this fixes that. Tested on Node 18. [`createRequire` was added in 12.2.0](https://nodejs.org/api/module.html#modulecreaterequirefilename) so I expect it to work back that far.